### PR TITLE
Add mariadb 11

### DIFF
--- a/sql/mariadb/egg-maria-d-b114.json
+++ b/sql/mariadb/egg-maria-d-b114.json
@@ -1,0 +1,32 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "meta": {
+        "version": "PLCN_v1",
+        "update_url": null
+    },
+    "exported_at": "2025-02-25T20:28:38+00:00",
+    "name": "MariaDB 11.4",
+    "author": "parker@parkervcp.com",
+    "uuid": "efad9890-b46d-43e2-8719-6a6cc3469b0d",
+    "description": "One of the most popular database servers. Made by the original developers of MySQL. Guaranteed to stay open source.",
+    "features": [],
+    "docker_images": {
+        "MariaDB 11.4": "ghcr.io\/parkervcp\/yolks:mariadb_11.4"
+    },
+    "file_denylist": [],
+    "startup": "{ \/usr\/sbin\/mariadbd --defaults-file=\/home\/container\/.my.cnf & } && sleep 5 && mariadb -u container",
+    "config": {
+        "files": "{\n    \".my.cnf\": {\n        \"parser\": \"file\",\n        \"find\": {\n            \"port\": \"port = {{server.allocations.default.port}}\",\n            \"bind-address\": \"bind-address=0.0.0.0\"\n        }\n    }\n}",
+        "startup": "{\n    \"done\": \"ready for connections\"\n}",
+        "logs": "{}",
+        "stop": "shutdown; exit;"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\n# MariaDB Installation Script\n#\n# Server Files: \/mnt\/server\nset -x\n\necho -e \"installing dependencies\"\napt-get -y update\napt-get -y install curl\n\n## add user\necho -e \"adding container user\"\nuseradd -d \/home\/container -m container -s \/bin\/bash\n\n## own server to container user\nchown container: \/mnt\/server\/\n\n## mkdir and install db\necho -e \"installing mariadb database\"\nrunuser -l container -c 'mkdir -p \/mnt\/server\/run\/mariadbd'\nrunuser -l container -c 'mkdir -p \/mnt\/server\/log\/mariadb'\nrunuser -l container -c 'mkdir \/mnt\/server\/mariadb'\n\n## get install config\nrunuser -l container -c 'curl https:\/\/raw.githubusercontent.com\/pelican-eggs\/database\/refs\/heads\/main\/sql\/mariadb\/install.maria.cnf > \/mnt\/server\/install.maria.cnf'\n\n# install with install config\nrunuser -l container -c 'mariadb-install-db --defaults-file=\/mnt\/server\/install.maria.cnf'\n\n## remove install config\nrm \/mnt\/server\/install.maria.cnf\n\nif [ ! -f \/mnt\/server\/.my.cnf ]; then\n    curl https:\/\/raw.githubusercontent.com\/pelican-eggs\/database\/refs\/heads\/main\/sql\/mariadb\/.maria.cnf > \/mnt\/server\/.my.cnf\nfi\n\necho -e \"install complete\"\n\nexit",
+            "container": "mariadb:11.4",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": []
+}

--- a/sql/mariadb/egg-maria-d-b115.json
+++ b/sql/mariadb/egg-maria-d-b115.json
@@ -1,0 +1,32 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "meta": {
+        "version": "PLCN_v1",
+        "update_url": null
+    },
+    "exported_at": "2025-02-25T20:28:39+00:00",
+    "name": "MariaDB 11.5",
+    "author": "parker@parkervcp.com",
+    "uuid": "b376eda5-e338-4507-b4f4-e11f949d4214",
+    "description": "One of the most popular database servers. Made by the original developers of MySQL. Guaranteed to stay open source.",
+    "features": [],
+    "docker_images": {
+        "MariaDB 11.5": "ghcr.io\/parkervcp\/yolks:mariadb_11.5"
+    },
+    "file_denylist": [],
+    "startup": "{ \/usr\/sbin\/mariadbd --defaults-file=\/home\/container\/.my.cnf & } && sleep 5 && mariadb -u container",
+    "config": {
+        "files": "{\n    \".my.cnf\": {\n        \"parser\": \"file\",\n        \"find\": {\n            \"port\": \"port = {{server.allocations.default.port}}\",\n            \"bind-address\": \"bind-address=0.0.0.0\"\n        }\n    }\n}",
+        "startup": "{\n    \"done\": \"ready for connections.\"\n}",
+        "logs": "{}",
+        "stop": "shutdown; exit;"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\n# MariaDB Installation Script\n#\n# Server Files: \/mnt\/server\nset -x\n\necho -e \"installing dependencies\"\napt-get -y update\napt-get -y install curl\n\n## add user\necho -e \"adding container user\"\nuseradd -d \/home\/container -m container -s \/bin\/bash\n\n## own server to container user\nchown container: \/mnt\/server\/\n\n## mkdir and install db\necho -e \"installing mariadb database\"\nrunuser -l container -c 'mkdir -p \/mnt\/server\/run\/mariadbd'\nrunuser -l container -c 'mkdir -p \/mnt\/server\/log\/mariadb'\nrunuser -l container -c 'mkdir \/mnt\/server\/mariadb'\n\n## get install config\nrunuser -l container -c 'curl https:\/\/raw.githubusercontent.com\/pelican-eggs\/database\/refs\/heads\/main\/sql\/mariadb\/install.maria.cnf > \/mnt\/server\/install.maria.cnf'\n\n# install with install config\nrunuser -l container -c 'mariadb-install-db --defaults-file=\/mnt\/server\/install.maria.cnf'\n\n## remove install config\nrm \/mnt\/server\/install.maria.cnf\n\nif [ ! -f \/mnt\/server\/.my.cnf ]; then\n    curl https:\/\/raw.githubusercontent.com\/pelican-eggs\/database\/refs\/heads\/main\/sql\/mariadb\/.maria.cnf > \/mnt\/server\/.my.cnf\nfi\n\necho -e \"install complete\"\n\nexit",
+            "container": "mariadb:11.5",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": []
+}

--- a/sql/mariadb/egg-pterodactyl-maria-d-b10-3.json
+++ b/sql/mariadb/egg-pterodactyl-maria-d-b10-3.json
@@ -1,0 +1,31 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2025-02-25T20:56:41+00:00",
+    "name": "MariaDB 10.3",
+    "author": "parker@parkervcp.com",
+    "description": "One of the most popular database servers. Made by the original developers of MySQL. Guaranteed to stay open source.",
+    "features": null,
+    "docker_images": {
+        "MariaDB 10.3": "ghcr.io\/parkervcp\/yolks:mariadb_10.3"
+    },
+    "file_denylist": [],
+    "startup": "{ \/usr\/sbin\/mysqld & } && sleep 5 && mysql -u root",
+    "config": {
+        "files": "{\r\n    \".my.cnf\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"port\": \"port = {{server.build.default.port}}\",\r\n            \"bind-address\": \"bind-address=0.0.0.0\"\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"mysqld: ready for connections\"\r\n}",
+        "logs": "{}",
+        "stop": "shutdown; exit;"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# MariaDB Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\nset -x\r\n\r\necho -e \"installing dependencies\"\r\napt-get -y update\r\napt-get -y install curl\r\n\r\n## add user\r\necho -e \"adding container user\"\r\nuseradd -d \/home\/container -m container -s \/bin\/bash\r\n\r\n## own server to container user\r\nchown container: \/mnt\/server\/\r\n\r\n## run install script as user\r\necho -e \"getting my.conf\"\r\nif [ -f \/mnt\/server\/.my.cnf ]; then\r\n    echo -e \"moving current config for install\"\r\n    mv \/mnt\/server\/.my.cnf \/mnt\/server\/custom.my.cnf\r\n    runuser -l container -c 'curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/database\/sql\/mariadb\/install.my.cnf > \/mnt\/server\/.my.cnf'\r\nelse\r\n    runuser -l container -c 'curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/database\/sql\/mariadb\/install.my.cnf > \/mnt\/server\/.my.cnf'\r\nfi\r\n\r\n## mkdir and install db\r\necho -e \"installing mysql database\"\r\nrunuser -l container -c 'mkdir -p \/mnt\/server\/run\/mysqld'\r\nrunuser -l container -c 'mkdir -p \/mnt\/server\/log\/mysql'\r\nrunuser -l container -c 'mkdir \/mnt\/server\/mysql'\r\n\r\nrunuser -l container -c 'mysql_install_db --defaults-file=\/mnt\/server\/.my.cnf'\r\n\r\nif [ -f \/mnt\/server\/custom.my.cnf ]; then\r\n    echo -e \"moving current config back in place\"\r\n    mv \/mnt\/server\/custom.my.cnf \/mnt\/server\/.my.cnf\r\nelse\r\n    curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/database\/sql\/mariadb\/my.cnf > \/mnt\/server\/.my.cnf\r\nfi\r\n\r\necho -e \"install complete\"\r\n\r\nexit",
+            "container": "mariadb:10.3",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": []
+}


### PR DESCRIPTION
# Description

Adds mariadb 11.3 and 11.4 for pelican

updates pterodactyl version of 10.3

resolves #6 

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel