### PR TITLE
mariadb: listen on dual-stack interface

### DIFF
--- a/sql/mariadb/.maria.cnf
+++ b/sql/mariadb/.maria.cnf
@@ -10,7 +10,7 @@ socket		        = /home/container/run/mariadbd/mariadbd.sock
 [mysqld]
 pid-file	        = /home/container/run/mariadbd/mariadbd.pid
 socket		        = /home/container/run/mariadbd/mariadbd.sock
-bind-address        = 0.0.0.0
+bind-address        = ::0
 port		        = 3306
 datadir             = /home/container/mariadb
 language            = /usr/local/share/mysql/english

--- a/sql/mariadb/egg-maria-d-b10-3.json
+++ b/sql/mariadb/egg-maria-d-b10-3.json
@@ -16,7 +16,7 @@
     "file_denylist": [],
     "startup": "{ \/usr\/sbin\/mysqld & } && sleep 5 && mysql -u root",
     "config": {
-        "files": "{\r\n    \".my.cnf\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"port\": \"port = {{server.build.default.port}}\",\r\n            \"bind-address\": \"bind-address=0.0.0.0\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \".my.cnf\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"port\": \"port = {{server.build.default.port}}\",\r\n            \"bind-address\": \"bind-address=::0\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"mysqld: ready for connections\"\r\n}",
         "logs": "{}",
         "stop": "shutdown; exit;"

--- a/sql/mariadb/egg-maria-d-b114.json
+++ b/sql/mariadb/egg-maria-d-b114.json
@@ -16,7 +16,7 @@
     "file_denylist": [],
     "startup": "{ \/usr\/sbin\/mariadbd --defaults-file=\/home\/container\/.my.cnf & } && sleep 5 && mariadb -u container",
     "config": {
-        "files": "{\n    \".my.cnf\": {\n        \"parser\": \"file\",\n        \"find\": {\n            \"port\": \"port = {{server.allocations.default.port}}\",\n            \"bind-address\": \"bind-address=0.0.0.0\"\n        }\n    }\n}",
+        "files": "{\n    \".my.cnf\": {\n        \"parser\": \"file\",\n        \"find\": {\n            \"port\": \"port = {{server.allocations.default.port}}\",\n            \"bind-address\": \"bind-address=::0\"\n        }\n    }\n}",
         "startup": "{\n    \"done\": \"ready for connections\"\n}",
         "logs": "{}",
         "stop": "shutdown; exit;"

--- a/sql/mariadb/egg-maria-d-b115.json
+++ b/sql/mariadb/egg-maria-d-b115.json
@@ -16,7 +16,7 @@
     "file_denylist": [],
     "startup": "{ \/usr\/sbin\/mariadbd --defaults-file=\/home\/container\/.my.cnf & } && sleep 5 && mariadb -u container",
     "config": {
-        "files": "{\n    \".my.cnf\": {\n        \"parser\": \"file\",\n        \"find\": {\n            \"port\": \"port = {{server.allocations.default.port}}\",\n            \"bind-address\": \"bind-address=0.0.0.0\"\n        }\n    }\n}",
+        "files": "{\n    \".my.cnf\": {\n        \"parser\": \"file\",\n        \"find\": {\n            \"port\": \"port = {{server.allocations.default.port}}\",\n            \"bind-address\": \"bind-address=::0\"\n        }\n    }\n}",
         "startup": "{\n    \"done\": \"ready for connections.\"\n}",
         "logs": "{}",
         "stop": "shutdown; exit;"

--- a/sql/mariadb/egg-pterodactyl-maria-d-b10-3.json
+++ b/sql/mariadb/egg-pterodactyl-maria-d-b10-3.json
@@ -15,7 +15,7 @@
     "file_denylist": [],
     "startup": "{ \/usr\/sbin\/mysqld & } && sleep 5 && mysql -u root",
     "config": {
-        "files": "{\r\n    \".my.cnf\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"port\": \"port = {{server.build.default.port}}\",\r\n            \"bind-address\": \"bind-address=0.0.0.0\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \".my.cnf\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"port\": \"port = {{server.build.default.port}}\",\r\n            \"bind-address\": \"bind-address=::0\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"mysqld: ready for connections\"\r\n}",
         "logs": "{}",
         "stop": "shutdown; exit;"

--- a/sql/mariadb/install.my.cnf
+++ b/sql/mariadb/install.my.cnf
@@ -164,7 +164,7 @@ innodb_flush_method	= O_DIRECT
 #
 # Allow server to accept connections on all interfaces.
 #
-bind-address=0.0.0.0
+bind-address=::0
 #
 # Optional setting
 #wsrep_slave_threads=1

--- a/sql/mariadb/my.cnf
+++ b/sql/mariadb/my.cnf
@@ -44,7 +44,7 @@ skip-external-locking
 #
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
-bind-address=0.0.0.0
+bind-address=::0
 #
 # * Fine Tuning
 #
@@ -165,7 +165,7 @@ innodb_flush_method	= O_DIRECT
 #
 # Allow server to accept connections on all interfaces.
 #
-bind-address=0.0.0.0
+bind-address=::0
 #
 # Optional setting
 #wsrep_slave_threads=1


### PR DESCRIPTION
# Description

Allows MariaDB to listen on both IPv4 and IPv6 interfaces. Tested only on 11.5 so far, but I don't see anything that would break on older versions.

This may at most only break for users who completely disable the IPv6 stack in their kernel (`ipv6.disable=1`), which is something you should not do anyway.

See: https://dev.mysql.com/doc/refman/9.1/en/ipv6-server-config.html

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: I will use another branch if I ever PR again.

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [ ] The egg was exported from the panel
  * If not, why?:  intentionally no as it seemed to bump version of the schema? I kept the patches to the minimum
